### PR TITLE
add a basic podspec for INKFramework

### DIFF
--- a/InkiOSFramework.podspec
+++ b/InkiOSFramework.podspec
@@ -1,0 +1,26 @@
+Pod::Spec.new do |s|
+  s.name = 'InkiOSFramework'
+  s.version = '0.4.4'
+  s.summary = 'Ink iOS Framework'
+  s.description = <<-DESC
+                    The Ink mobile framework for iOS. Connect your app with others to enable
+                    new workflows and capabilities for your users.
+                  DESC
+  s.homepage = 'http://inkmobility.com'
+  s.license = {
+    :type => 'Copyright',
+    :text => 'http://inkmobility.com/license'
+  }
+  s.author = 'Cloudtop Inc.'
+
+  s.source = { :http => 'https://github.com/Ink/InkiOSFramework.git'}
+  s.platform = :ios
+  s.ios.deployment_target = '6.0'
+
+  s.vendored_frameworks = 'Library/INK.framework'
+  s.resource = 'Library/INK.bundle'
+
+  s.frameworks = 'MobileCoreServices', 'CFNetwork', 'Accelerate', 'Security', 'SystemConfiguration', 'QuickLook', 'QuartzCore', 'CoreGraphics'
+  s.libraries = 'sqlite3.0', 'icucore'
+  s.xcconfig = { 'OTHER_LDFLAGS' => '-all_load -lz' }
+end


### PR DESCRIPTION
Hey guys - you should consider creating a podspec for your framework since a lot of people use cocoapods to _search_ and include library code for ios projects. It also will generate docs for you. Here is an example you guys can work from. I did this pretty quickly but I think it should work, I would just make sure to test that resources are resolved correctly via the bundle.

When it's ready you can submit a pull request to the CocoaPods repot to have it made available in the pod search index. 
https://github.com/CocoaPods/Specs/ 
